### PR TITLE
Add automatic support for ARM

### DIFF
--- a/src/function/PhpFpmFunction.ts
+++ b/src/function/PhpFpmFunction.ts
@@ -43,7 +43,7 @@ export class PhpFpmFunction extends Function {
         const phpVersion = props.phpVersion ?? functionDefaults.phpVersion;
         this.addLayers(
             // Add the FPM layer first so that other layers can override it
-            fpmLayer(this, region, phpVersion, functionDefaults.platform),
+            fpmLayer(this, region, phpVersion, props.architecture ?? functionDefaults.architecture),
             ...layers
         );
     }

--- a/src/function/PhpFunction.ts
+++ b/src/function/PhpFunction.ts
@@ -44,7 +44,12 @@ export class PhpFunction extends Function {
         const phpVersion = props.phpVersion ?? functionDefaults.phpVersion;
         this.addLayers(
             // Add the function layer first so that other layers can override it
-            functionLayer(this, region, phpVersion, functionDefaults.platform),
+            functionLayer(
+                this,
+                region,
+                phpVersion,
+                props.architecture ?? functionDefaults.architecture
+            ),
             ...layers
         );
     }

--- a/src/function/defaults.ts
+++ b/src/function/defaults.ts
@@ -1,11 +1,12 @@
 import { IVpc, SecurityGroup, SubnetSelection, SubnetType } from 'aws-cdk-lib/aws-ec2';
 import { VpcForServerlessApp } from '../vpc/VpcForServerlessApp';
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
 
 export const functionDefaults = {
     path: process.cwd(),
     phpVersion: '8.1',
     memorySize: 1024,
-    platform: 'x86',
+    architecture: Architecture.X86_64,
     excludedPhpPaths: ['.git', '.idea', 'cdk.out', 'node_modules', '.bref', '.serverless', 'tests'],
 } as const;
 

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -1,4 +1,4 @@
-import { ILayerVersion, LayerVersion } from 'aws-cdk-lib/aws-lambda';
+import { Architecture, ILayerVersion, LayerVersion } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import { functionLayerArn, fpmLayerArn, consoleLayerArn } from '@bref.sh/layers';
 
@@ -6,8 +6,10 @@ export function functionLayer(
     scope: Construct,
     region: string,
     phpVersion: string,
-    platform: 'x86' | 'arm'
+    architecture: Architecture
 ): ILayerVersion {
+    const platform = architecture === Architecture.X86_64 ? 'x86' : 'arm';
+
     return LayerVersion.fromLayerVersionArn(
         scope,
         'BrefFunctionLayer',
@@ -19,8 +21,10 @@ export function fpmLayer(
     scope: Construct,
     region: string,
     phpVersion: string,
-    platform: 'x86' | 'arm'
+    architecture: Architecture
 ): ILayerVersion {
+    const platform = architecture === Architecture.X86_64 ? 'x86' : 'arm';
+
     return LayerVersion.fromLayerVersionArn(
         scope,
         'BrefFpmLayer',

--- a/test/function/ConsoleFunction.test.ts
+++ b/test/function/ConsoleFunction.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { ConsoleFunction } from '../../src';
 import { compileTestStack } from '../helper';
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
+import { mapValues } from 'lodash';
 
 describe('ConsoleFunction', () => {
     it('adds the console layer', () => {
@@ -15,6 +17,22 @@ describe('ConsoleFunction', () => {
         expect(layers).length(2);
         expect(layers[0]).to.match(/arn:aws:lambda:us-east-1:534081306603:layer:php-81:\d+/);
         expect(layers[1]).to.match(/arn:aws:lambda:us-east-1:534081306603:layer:console:\d+/);
+    });
+
+    it('supports ARM', () => {
+        const template = compileTestStack((stack) => {
+            new ConsoleFunction(stack, 'Console', {
+                handler: 'index.php',
+                architecture: Architecture.ARM_64,
+            });
+        });
+
+        mapValues(template.findResources('AWS::Lambda::Function'), (resource) => {
+            expect(resource.Properties.Architectures).toEqual(['arm64']);
+            expect(resource.Properties.Layers[0]).matches(
+                /arn:aws:lambda:us-east-1:534081306603:layer:arm-php-81:\d+/
+            );
+        });
     });
 
     // https://github.com/brefphp/constructs/issues/1

--- a/test/function/PhpFpmFunction.test.ts
+++ b/test/function/PhpFpmFunction.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { PhpFpmFunction } from '../../src';
 import { cleanupTemplate, compileTestStack } from '../helper';
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
+import { mapValues } from 'lodash';
 
 describe('PhpFpmFunction', () => {
     it('builds', () => {
@@ -9,6 +11,21 @@ describe('PhpFpmFunction', () => {
         }).toJSON();
 
         expect(cleanupTemplate(template).Resources).toMatchSnapshot();
+    });
+
+    it('supports ARM', () => {
+        const template = compileTestStack((stack) => {
+            new PhpFpmFunction(stack, 'Function', {
+                architecture: Architecture.ARM_64,
+            });
+        });
+
+        mapValues(template.findResources('AWS::Lambda::Function'), (resource) => {
+            expect(resource.Properties.Architectures).toEqual(['arm64']);
+            expect(resource.Properties.Layers[0]).matches(
+                /arn:aws:lambda:us-east-1:534081306603:layer:arm-php-81-fpm:\d+/
+            );
+        });
     });
 
     // https://github.com/brefphp/constructs/issues/1

--- a/test/function/PhpFunction.test.ts
+++ b/test/function/PhpFunction.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { PhpFunction } from '../../src';
 import { cleanupTemplate, compileTestStack } from '../helper';
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
+import { mapValues } from 'lodash';
 
 describe('PhpFunction', () => {
     it('builds', () => {
@@ -11,6 +13,22 @@ describe('PhpFunction', () => {
         }).toJSON();
 
         expect(cleanupTemplate(template).Resources).toMatchSnapshot();
+    });
+
+    it('supports ARM', () => {
+        const template = compileTestStack((stack) => {
+            new PhpFunction(stack, 'Function', {
+                handler: 'index.php',
+                architecture: Architecture.ARM_64,
+            });
+        });
+
+        mapValues(template.findResources('AWS::Lambda::Function'), (resource) => {
+            expect(resource.Properties.Architectures).toEqual(['arm64']);
+            expect(resource.Properties.Layers[0]).matches(
+                /arn:aws:lambda:us-east-1:534081306603:layer:arm-php-81:\d+/
+            );
+        });
     });
 
     // https://github.com/brefphp/constructs/issues/1


### PR DESCRIPTION
See #2

Setting the architecture to ARM is now enough for Bref to automatically pick the right ARM layer:

```ts
new PhpFpmFunction(this, 'Function',{
           ...
           architecture: Architecture.ARM_64,
});
```