### PR TITLE
Properly orders php layers to allow extension

### DIFF
--- a/src/function/ConsoleFunction.ts
+++ b/src/function/ConsoleFunction.ts
@@ -1,12 +1,48 @@
-import { Stack } from 'aws-cdk-lib';
+import {Duration, Stack} from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { consoleLayer } from '../layers';
-import { PhpFunction, PhpFunctionProps } from './PhpFunction';
+import {consoleLayer, functionLayer} from '../layers';
+import {Function, FunctionProps, Runtime} from "aws-cdk-lib/aws-lambda";
+import {IVpc} from "aws-cdk-lib/aws-ec2";
+import {VpcForServerlessApp} from "../vpc/VpcForServerlessApp";
+import {functionDefaults, vpcDefaults} from "./defaults";
+import {packagePhpCode} from "../package";
 
-export class ConsoleFunction extends PhpFunction {
-    constructor(scope: Construct, id: string, props: PhpFunctionProps) {
-        super(scope, id, props);
+export type PhpConsoleFunctionProps = Partial<FunctionProps> & {
+    phpVersion?: '8.0' | '8.1' | '8.2';
+    handler: string;
+    vpc?: IVpc | VpcForServerlessApp;
+};
 
-        this.addLayers(consoleLayer(this, Stack.of(scope).region));
+export class ConsoleFunction extends Function {
+    constructor(scope: Construct, id: string, props: PhpConsoleFunctionProps) {
+        const defaults = {
+            runtime: Runtime.PROVIDED_AL2,
+            code: props.code ?? packagePhpCode(),
+            timeout: Duration.seconds(6),
+            memorySize: functionDefaults.memorySize,
+        };
+
+        const layers = props.layers ?? [];
+
+        super(scope, id, {
+            ...props,
+            ...vpcDefaults(props.vpc),
+            layers: [],
+            ...defaults,
+        });
+
+        this.addLayers(
+            ...layers,
+            consoleLayer(
+                this,
+                Stack.of(scope).region
+            ),
+            // Adds the function layer last so that others(in this case console depends on it) can override it
+            functionLayer(
+                this,
+                Stack.of(scope).region,
+                props.phpVersion ?? functionDefaults.phpVersion,
+                props.architecture ?? functionDefaults.architecture)
+        );
     }
 }

--- a/src/function/PhpFpmFunction.ts
+++ b/src/function/PhpFpmFunction.ts
@@ -42,9 +42,9 @@ export class PhpFpmFunction extends Function {
         }
         const phpVersion = props.phpVersion ?? functionDefaults.phpVersion;
         this.addLayers(
-            // Add the FPM layer first so that other layers can override it
+            ...layers,
+            // Add the FPM layer last so that other layers can override it
             fpmLayer(this, region, phpVersion, props.architecture ?? functionDefaults.architecture),
-            ...layers
         );
     }
 }

--- a/src/function/PhpFunction.ts
+++ b/src/function/PhpFunction.ts
@@ -43,14 +43,14 @@ export class PhpFunction extends Function {
         }
         const phpVersion = props.phpVersion ?? functionDefaults.phpVersion;
         this.addLayers(
-            // Add the function layer first so that other layers can override it
+            ...layers,
+            // Add the function layer last so that other layers can override it
             functionLayer(
                 this,
                 region,
                 phpVersion,
                 props.architecture ?? functionDefaults.architecture
             ),
-            ...layers
         );
     }
 }

--- a/test/function/PhpFunction.test.ts
+++ b/test/function/PhpFunction.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { PhpFunction } from '../../src';
 import { cleanupTemplate, compileTestStack } from '../helper';
-import { Architecture } from 'aws-cdk-lib/aws-lambda';
+import {Architecture, LayerVersion} from 'aws-cdk-lib/aws-lambda';
 import { mapValues } from 'lodash';
 
 describe('PhpFunction', () => {
@@ -43,5 +43,20 @@ describe('PhpFunction', () => {
         });
 
         template.resourceCountIs('AWS::Lambda::Function', 2);
+    });
+
+    it('adds additional layer before php layer', () => {
+        const template = compileTestStack((stack) => {
+            new PhpFunction(stack, 'Console', {
+                handler: 'index.php',
+                layers: [LayerVersion.fromLayerVersionArn(stack, 'Layer', 'arn:aws:lambda:us-east-1:123456789012:layer:layer-name:1')],
+            });
+        });
+
+        const phpFunction = template.findResources('AWS::Lambda::Function');
+        const layers = phpFunction.Console63CA37A7.Properties.Layers;
+        expect(layers).length(2);
+        expect(layers[1]).to.match(/arn:aws:lambda:us-east-1:534081306603:layer:php-81:\d+/);
+        expect(layers[0]).to.match(/arn:aws:lambda:us-east-1:123456789012:layer:layer-name:1/);
     });
 });


### PR DESCRIPTION
Based on this discussion [#1560](https://github.com/brefphp/bref/discussions/1560#discussioncomment-6140257)

This changes the merge order of lambda layers, previously the php layer was added last, which lead to the console layer not being able to properly override the php layer.

The confusing part: The order of the array you pass into `addLayers(...ILayerVersion[])` is actually reversed when you deploy it.

Not sure if this would be a bug or a feature request for the cdk repository, since you would not run into this issue if layers are independent.