### PR TITLE
Resolve incorrect order of lambda layers with context flag @aws-cdk/aws-lambda:recognizeLayerVersion

### DIFF
--- a/src/layers.ts
+++ b/src/layers.ts
@@ -12,7 +12,7 @@ export function functionLayer(
 
     return LayerVersion.fromLayerVersionArn(
         scope,
-        'BrefFunctionLayer',
+        'Bref001FunctionLayer',
         functionLayerArn(region, phpVersion, platform)
     );
 }
@@ -27,11 +27,11 @@ export function fpmLayer(
 
     return LayerVersion.fromLayerVersionArn(
         scope,
-        'BrefFpmLayer',
+        'Bref101FpmLayer',
         fpmLayerArn(region, phpVersion, platform)
     );
 }
 
 export function consoleLayer(scope: Construct, region: string): ILayerVersion {
-    return LayerVersion.fromLayerVersionArn(scope, 'BrefConsoleLayer', consoleLayerArn(region));
+    return LayerVersion.fromLayerVersionArn(scope, 'Bref201ConsoleLayer', consoleLayerArn(region));
 }

--- a/test/function/ConsoleFunction.test.ts
+++ b/test/function/ConsoleFunction.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { ConsoleFunction } from '../../src';
 import { compileTestStack } from '../helper';
+import { cx_api } from 'aws-cdk-lib';
 import { Architecture } from 'aws-cdk-lib/aws-lambda';
 import { mapValues } from 'lodash';
 
@@ -11,6 +12,20 @@ describe('ConsoleFunction', () => {
                 handler: 'index.php',
             });
         });
+
+        const consoleFunction = template.findResources('AWS::Lambda::Function');
+        const layers = consoleFunction.Console63CA37A7.Properties.Layers;
+        expect(layers).length(2);
+        expect(layers[0]).to.match(/arn:aws:lambda:us-east-1:534081306603:layer:php-81:\d+/);
+        expect(layers[1]).to.match(/arn:aws:lambda:us-east-1:534081306603:layer:console:\d+/);
+    });
+
+    it('adds the console layer with recognizeLayerVersion flag', () => {
+        const template = compileTestStack((stack) => {
+            new ConsoleFunction(stack, 'Console', {
+                handler: 'index.php',
+            });
+        }, { context: { [cx_api.LAMBDA_RECOGNIZE_LAYER_VERSION]: true } });
 
         const consoleFunction = template.findResources('AWS::Lambda::Function');
         const layers = consoleFunction.Console63CA37A7.Properties.Layers;

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,9 +1,10 @@
-import { Stack } from 'aws-cdk-lib';
+import { App, AppProps, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { mapValues } from 'lodash';
 
-export function compileTestStack(definition: (stack: Stack) => void): Template {
-    const stack = new Stack(undefined, 'app', {
+export function compileTestStack(definition: (stack: Stack) => void, appProps: AppProps = undefined): Template {
+    const app = new App(appProps);
+    const stack = new Stack(app, 'app', {
         env: { region: 'us-east-1' },
     });
     definition(stack);


### PR DESCRIPTION
Based on discussions [1560](https://github.com/brefphp/bref/discussions/1560), [1580](https://github.com/brefphp/bref/discussions/1580) and pull request #4 

New cdk projects created with `cdk init` provides set of [feature flags](https://github.com/aws/aws-cdk/blob/main/packages/%40aws-cdk/cx-api/FEATURE_FLAGS.md). Specifically [@aws-cdk/aws-lambda:recognizeVersionProps](https://github.com/aws/aws-cdk/blob/main/packages/%40aws-cdk/cx-api/FEATURE_FLAGS.md#aws-cdkaws-lambdarecognizeversionprops) which changes order of lambda layers (see [Function.renderLayers](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-lambda/lib/function.ts#L1177)).

This pull request changes `id`s of created layers (based on their priorities described in corresponding constructs) and allows to create test templates with `AppProps`.

There might be a problem if you want to add additional layers to bref construct along with mentioned flag.
To resolve such problems, you may need to "name" additional layers correctly (so they are sorted as you wish in previously mentioned `renderLayers` method).